### PR TITLE
WIP: Expiry warning

### DIFF
--- a/app/views/confirmations/_footer.html.slim
+++ b/app/views/confirmations/_footer.html.slim
@@ -1,5 +1,9 @@
+.text-panel
+  .util_mt-large
+    p = t('confirmation.expiry')
+
 .js-only.no-print
-  p.util_mt-large =link_to(t('confirmation.print'), '#', class: 'js-print')
+  p.util_mt-medium =link_to(t('confirmation.print'), '#', class: 'js-print')
 
 = form_tag(finish_session_path, method: :post, class: 'util_mb-medium util_mt-medium') do
   = submit_tag(t('confirmation.finish'), class: 'button', role: 'button')

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -244,6 +244,7 @@ cy:
         three: E-bostiwch neu anfonwch eich llythyr i'r tribiwnlys sy'n gwrando eich achos.
         two: Gallwch chi gopïo'r llythyr isod i mewn i e-bost neu argraffu'r dudalen hon.
       title: Nid yw'ch cais wedi'i gwblhau eto
+    expiry: "Mae eich cyfeirnod help i dalu ffioedd yn ddilys i’w ddefnyddio unwaith, ac mae’n dod i ben ar ôl 3 mis. Rhaid i chi wneud cais arall os oes arnoch angen rhagor o help i dalu ffioedd."
     feedback:
       heading: Rhowch eich barn am y gwasanaeth i helpu i'w wella
       link: Rhowch eich adborth i ni

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,7 @@ en:
         three: Email or send your letter to the tribunal where your case is being heard.
         two: You can copy the letter below into an email or print this page.
       title: Your application is not finished yet
+    expiry: 'Your help with fees reference number is valid for a single use, and expires after 3 months. Please apply again if you need further help with fees.'
     feedback:
       heading: Tell us what you think and help improve the service
       link: Give us your feedback


### PR DESCRIPTION
Show a warning to users that the reference will expire in three months.

This links to the purging of expired applications on the staff-app.

## DO NOT MERGE

Wait until https://github.com/ministryofjustice/fr-staffapp/pull/737 has been approved