### PR TITLE
RST-487 added capybara accessible to cucumber tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara-accessible', '~> 0.2.1'
+  gem 'capybara-accessible', '~> 0.2.1', require: false
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'chromedriver-helper', '~> 1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development do
 end
 
 group :test do
+  gem 'capybara-accessible', '~> 0.2.1'
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'chromedriver-helper', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-accessible (0.2.1)
+      capybara (~> 2.0)
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
@@ -328,6 +330,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  capybara-accessible (~> 0.2.1)
   capybara-screenshot
   chromedriver-helper (~> 1.1)
   codeclimate-test-reporter
@@ -366,4 +369,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.15.1
+   1.16.0.pre.2

--- a/features/support/capybara_driver_helper.rb
+++ b/features/support/capybara_driver_helper.rb
@@ -11,6 +11,10 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, js_errors: false, timeout: 60)
 end
 
+Capybara.register_driver :accessibility do |app|
+  Capybara::Accessible::Driver.new(app)
+end
+
 Capybara.register_driver :saucelabs do |app|
   browser = Settings.saucelabs.browsers.send(Settings.saucelabs.browser).to_h
 
@@ -46,7 +50,7 @@ Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |scenario|
 end
 
 Capybara.javascript_driver = Capybara.default_driver
-Capybara.current_driver = Capybara.default_driver
+Capybara.current_driver = Capybara.default_driver = :accessible
 Capybara.app_host = 'http://localhost:3000'
 Capybara.server_host = 'localhost'
 Capybara.server_port = '3000'

--- a/features/support/capybara_driver_helper.rb
+++ b/features/support/capybara_driver_helper.rb
@@ -1,3 +1,41 @@
+require 'capybara/accessible' if ENV['ACCESSIBLE'] == 'true'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, js_errors: false, timeout: 60)
+end
+
+Capybara.register_driver :saucelabs do |app|
+  browser = Settings.saucelabs.browsers.send(Settings.saucelabs.browser).to_h
+  accessible_selenium_adapter_for do
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: Settings.saucelabs.url, desired_capabilities: browser)
+  end
+end
+
+Capybara.register_driver :firefox do |app|
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  profile['browser.cache.disk.enable'] = false
+  profile['browser.cache.memory.enable'] = false
+  accessible_selenium_adapter_for do
+    Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile)
+  end
+end
+
+Capybara.register_driver :chrome do |app|
+  accessible_selenium_adapter_for do
+    Capybara::Selenium::Driver.new(app, browser: :chrome)
+  end
+end
+
+def accessible_selenium_adapter_for
+  driver = yield
+  if ENV['ACCESSIBLE'] == 'true'
+    adaptor = Capybara::Accessible::SeleniumDriverAdapter.new
+    Capybara::Accessible.setup(driver, adaptor)
+  else
+    driver
+  end
+end
+
 Capybara.configure do |config|
   driver = ENV['DRIVER']&.to_sym || :poltergeist
   config.default_driver = driver
@@ -5,31 +43,6 @@ Capybara.configure do |config|
   config.match = :prefer_exact
   config.ignore_hidden_elements = false
   config.visible_text_only = true
-end
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: false, timeout: 60)
-end
-
-Capybara.register_driver :accessibility do |app|
-  Capybara::Accessible::Driver.new(app)
-end
-
-Capybara.register_driver :saucelabs do |app|
-  browser = Settings.saucelabs.browsers.send(Settings.saucelabs.browser).to_h
-
-  Capybara::Selenium::Driver.new(app, browser: :remote, url: Settings.saucelabs.url, desired_capabilities: browser)
-end
-
-Capybara.register_driver :firefox do |app|
-  profile = Selenium::WebDriver::Firefox::Profile.new
-  profile['browser.cache.disk.enable'] = false
-  profile['browser.cache.memory.enable'] = false
-  Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile)
-end
-
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
 if ENV.key?('CIRCLE_ARTIFACTS')
@@ -50,7 +63,7 @@ Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |scenario|
 end
 
 Capybara.javascript_driver = Capybara.default_driver
-Capybara.current_driver = Capybara.default_driver = :accessible
+Capybara.current_driver = Capybara.default_driver
 Capybara.app_host = 'http://localhost:3000'
 Capybara.server_host = 'localhost'
 Capybara.server_port = '3000'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,7 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+require 'capybara/accessible'
 require 'cucumber/rails'
 require 'capybara/dsl'
 require 'capybara/poltergeist'

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -7,3 +7,7 @@ end
 Before('@zap') do
   IO.popen('/Applications/ZAP\ 2.6.0.app/Contents/Java/zap.sh -daemon')
 end
+
+Around('@inaccessible') do |block|
+  Capybara::Accessible.skip_audit { block.call }
+end


### PR DESCRIPTION
[JIRA](https://tools.hmcts.net/jira/browse/RST-487)
Accessibility testing using capybara-accessible 
[capybara-accessible](https://github.com/Casecommons/capybara-accessible)

All tests are passing but by breaking it by removing a label you can see the kind of output we'll get.
![screen shot 2017-10-26 at 11 31 23](https://user-images.githubusercontent.com/9287201/32049454-fac2e7ae-ba44-11e7-9573-13aa71581f07.png)
