### PR TITLE
Add the missing head section in the moj_template

### DIFF
--- a/app/views/layouts/moj_template.html.erb
+++ b/app/views/layouts/moj_template.html.erb
@@ -30,6 +30,7 @@
   <![endif]-->
 
   <%= yield :stylesheets %>
+  <%= yield :head %>
 
   <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
 </head>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2781

### Change description ###

This PR adds back the head section in the moj_template. 

All the `content_for :head` will be rendered again.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
