### PR TITLE
Rack update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.6)


### PR DESCRIPTION
There is a possible shell escape sequence injection vulnerability in the Lint
and CommonLogger components of Rack. This vulnerability has been assigned the
CVE identifier CVE-2022-30123.

