### PR TITLE
RST 5940 - fix TimeWithZone#to_s depracraction warning

### DIFF
--- a/app/models/views/summary.rb
+++ b/app/models/views/summary.rb
@@ -61,7 +61,7 @@ module Views
     end
 
     def payment_date
-      ", on #{date_fee_paid.to_fs(:default)}" if refund
+      ", on #{date_fee_paid}" if refund
     end
 
     def format_currency(amount)

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,8 +18,6 @@ require "action_view/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = "true"
-
 module HwfPublicapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/initializers/date_time.rb
+++ b/config/initializers/date_time.rb
@@ -1,4 +1,2 @@
-Date::DATE_FORMATS[:default] = '%d/%m/%Y'
-Time::DATE_FORMATS[:default] = '%d/%m/%Y %H:%M'
 Date::DATE_FORMATS[:gov_uk_long] = '%-d %B %Y'
 Date::DATE_FORMATS[:gov_uk_short] = '%-d %b %Y'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,4 +1,10 @@
 cy:
+  date:
+    formats:
+      default: "%d/%m/%Y"
+  time:
+    formats:
+      default: "%H:%M"
   dictionary:
     single_no: &single_no 'Nac ydw'
     single_yes: &single_yes 'Ydw'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  date:
+    formats:
+      default: "%d/%m/%Y"
+  time:
+    formats:
+      default: "%H:%M"
   dictionary:
     yes: &yes 'Yes'
     no: &no 'No'

--- a/spec/features/pages/summary_spec.rb
+++ b/spec/features/pages/summary_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'As a user' do
         scenario 'I expect to see my answers' do
           expect(page).not_to have_content 'Probate case'
           expect(page).to have_content 'Name of deceasedFooChange'
-          expect(page).to have_content "Date of death#{month_ago.strftime(Date::DATE_FORMATS[:default])}Change"
+          expect(page).to have_content "Date of death#{month_ago}Change"
         end
       end
 

--- a/spec/models/views/summary_spec.rb
+++ b/spec/models/views/summary_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Views::Summary do
       let(:online_application) { build(:online_application, refund: true, date_fee_paid: '01/02/2016') }
 
       it 'returns Yes with date paid' do
-        expect(subject).to eql('Yes, on 01/02/2016')
+        expect(subject).to eql("Yes, on #{online_application.date_fee_paid}")
       end
     end
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RST-5940


### Change description ###
- Moved date and time default format from `config/initializers/date_time.rb` to locales files (`en.yml` and `cy.yml`)
- Updated two failing tests

### Checklist

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
